### PR TITLE
Class must be marked as public, to make it visible to other classes i…

### DIFF
--- a/Dictionary.cs
+++ b/Dictionary.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Dictionary
 {
-    class Dictionary
+    public class EnglishDictionary
     {
         static void main()
         {


### PR DESCRIPTION
…n other files. Also, EnglishDictionary is a more descriptive name and doesn't conflict with generic Dictionary name